### PR TITLE
Relax Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = ">=3.8"
 textual = ">=0.39.0"
 textual-fspicker = "^0.0.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual-key-recorder"
-version = "0.1.0"
+version = "0.1.1"
 description = "A tool to help record what key names are known to Textual"
 authors = ["Dave Pearson <dave@textualize.io>"]
 license = "MIT"


### PR DESCRIPTION
Relax the required version of Python. This is what happens when you get `poetry` generate the config rather than hand-write.